### PR TITLE
Remove unused import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ notebooks*
 __pycache__
 *.egg-info
 gym_wordle/data/words.txt
+build/

--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ You can initialize and use the `gym_wordle` OpenAI environment and make random g
 
 ```
 import gym
-import gym_wordle
 from gym_wordle.exceptions import InvalidWordException
 
 env = gym.make('Wordle-v0')


### PR DESCRIPTION
The example in the README imports `gym_wordle`, but it's not used in the example. I also figure the `build/` directory should be part of the standard ignore list.

Thanks for creating this gym by the way :smile: 